### PR TITLE
make sure aws-k8s-tester directory exists

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -29,7 +29,8 @@ KUBECONFIG_PATH=${KUBECONFIG_PATH:-${TEST_CLUSTER_DIR}/kubeconfig}
 
 # shared binaries
 TESTER_DOWNLOAD_URL=https://github.com/aws/aws-k8s-tester/releases/download/v0.4.3/aws-k8s-tester-v0.4.3-$OS-$ARCH
-TESTER_PATH=${TESTER_PATH:-/tmp/aws-k8s-tester/aws-k8s-tester}
+TESTER_DIR=${TESTER_DIR:-/tmp/aws-k8s-tester}
+TESTER_PATH=${TESTER_PATH:-$TESTER_DIR/aws-k8s-tester}
 AUTHENTICATOR_PATH=${AUTHENTICATOR_PATH:-/tmp/aws-k8s-tester/aws-iam-authenticator}
 KUBECTL_PATH=${KUBECTL_PATH:-/tmp/aws-k8s-tester/kubectl}
 
@@ -51,8 +52,9 @@ mkdir -p $TEST_CLUSTER_DIR
 
 # Download aws-k8s-tester if not yet
 if [[ ! -e $TESTER_PATH ]]; then
+  mkdir -p $TESTER_DIR
   echo "Downloading aws-k8s-tester from $TESTER_DOWNLOAD_URL to $TESTER_PATH"
-  curl -L -X GET $TESTER_DOWNLOAD_URL -o $TESTER_PATH
+  curl -s -L -X GET $TESTER_DOWNLOAD_URL -o $TESTER_PATH
   chmod +x $TESTER_PATH
 fi
 


### PR DESCRIPTION
There was an issue with the run-integration-tests.sh script where the
aws-k8s-tester wasn't able to be downloaded due to the target
destination not existing. This fixes that by ensuring the destination
directory exists before downloading.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
